### PR TITLE
Remove -ffast-math

### DIFF
--- a/audio/playtone/Makefile
+++ b/audio/playtone/Makefile
@@ -42,7 +42,6 @@ EXEFS_SRC	:=	exefs_src
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 \
-			-ffast-math \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -DSWITCH

--- a/graphics/printing/hello-world/Makefile
+++ b/graphics/printing/hello-world/Makefile
@@ -42,7 +42,6 @@ EXEFS_SRC	:=	exefs_src
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 \
-			-ffast-math \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -DSWITCH

--- a/graphics/simplegfx/Makefile
+++ b/graphics/simplegfx/Makefile
@@ -42,7 +42,6 @@ EXEFS_SRC	:=	exefs_src
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 \
-			-ffast-math \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -DSWITCH

--- a/hid/irsensor/Makefile
+++ b/hid/irsensor/Makefile
@@ -42,7 +42,6 @@ EXEFS_SRC	:=	exefs_src
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 \
-			-ffast-math \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -DSWITCH

--- a/templates/application/Makefile
+++ b/templates/application/Makefile
@@ -42,7 +42,6 @@ EXEFS_SRC	:=	exefs_src
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 \
-			-ffast-math \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -DSWITCH

--- a/usb/usbds/Makefile
+++ b/usb/usbds/Makefile
@@ -42,7 +42,6 @@ EXEFS_SRC	:=	exefs_src
 ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE
 
 CFLAGS	:=	-g -Wall -O2 \
-			-ffast-math \
 			$(ARCH) $(DEFINES)
 
 CFLAGS	+=	$(INCLUDE) -DSWITCH


### PR DESCRIPTION
-ffast-math is a misleading compiler flag. It breaks the C standard, produces broken code in several cases, and in all doesn't really add any tangible performance benefit.

http://pointclouds.org/news/2011/08/29/ffast-math/
http://programerror.com/2009/09/when-gccs-ffast-math-isnt/
