### PR TITLE
doc: update templates/sysmodule readme

### DIFF
--- a/templates/sysmodule/README.md
+++ b/templates/sysmodule/README.md
@@ -1,6 +1,6 @@
 # sysmodule
 
-This template is for a sysmodule where the output .nsp is used by Atmosphère at: `sdmc:/atmosphere/titles/<titleid>/exefs.nsp`. To load the sysmodule at boot, the following file should exist: `sdmc:/atmosphere/titles/<titleid>/flags/boot2.flag`.
+This template is for a sysmodule where the output .nsp is used by Atmosphère at: `sdmc:/atmosphere/contents/<titleid>/exefs.nsp`. To load the sysmodule at boot, the following file should exist: `sdmc:/atmosphere/contents/<titleid>/flags/boot2.flag`.
 
 Where titleid is whatever you specify. Update the `$(TARGET).json` file with the titleid and any other changes.
 


### PR DESCRIPTION
Since Atmosphère `0.10.0` the correct folder to put the sysmodules is `/atmosphere/contents`, so this PR updates that
