### PR TITLE
Add targets per Makefile, allowing make -j to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
-MAKEFILES	:=	$(shell find . -mindepth 2 -name Makefile)
+TARGETS	:=	$(subst ./,,$(shell find . -mindepth 2 -name Makefile -printf "%h "))
 
 DATESTRING	:=	$(shell date +%Y)$(shell date +%m)$(shell date +%d)
 
-all:
-	@for i in $(MAKEFILES); do $(MAKE) -C `dirname $$i` || exit 1; done;
+all: $(TARGETS)
+
+.PHONY: $(TARGETS)
+
+$(TARGETS):
+	@$(MAKE) -C $@
 
 clean:
 	@rm -f *.bz2
-	@for i in $(MAKEFILES); do $(MAKE) -C `dirname $$i` clean || exit 1; done;
+	@for i in $(TARGETS); do $(MAKE) -C $$i clean || exit 1; done;
 
 dist: clean
 	@tar -cvjf switch-examples-$(DATESTRING).tar.bz2 *


### PR DESCRIPTION
As the commit log says, this breaks out the `MAKEFILES` variable instead into a list of directories that have Makefiles in them, which allows for a multi-target rule over the set of those directories. Without this, make -j cannot build more than one subdirectory at a time, which was somewhat frustrating to me. It also lets you say, e.g., `make audio/echo` to just build the `audio/echo` example while in the root directory.

This doesn't attempt to apply the same cleanup to the `clean` target since cleaning is much faster and I didn't want to get fiddly with more string substitutions; it didn't seem worth it to clean up that loop too.