### PR TITLE
account: add code to satisfy multiple accounts

### DIFF
--- a/account/source/main.c
+++ b/account/source/main.c
@@ -37,8 +37,8 @@ int main(int argc, char **argv)
         rc = accountGetPreselectedUser(&userID);
 
         if (R_FAILED(rc)) {
-            printf("accountGetPreselectedUser() failed: 0x%x, using pselUi..\n", rc);
-            
+            printf("accountGetPreselectedUser() failed: 0x%x, using pselShowUserSelector..\n", rc);
+
             /* Create player selection UI settings */
             PselUserSelectionSettings settings;
             memset(&settings, 0, sizeof(settings));
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
             rc = pselShowUserSelector(&userID, &settings);
 
             if (R_FAILED(rc)) {
-                printf("using pselShowUserSelector() failed: 0x%x\n", rc);
+                printf("pselShowUserSelector() failed: 0x%x\n", rc);
             }
         }
 

--- a/account/source/main.c
+++ b/account/source/main.c
@@ -37,7 +37,21 @@ int main(int argc, char **argv)
         rc = accountGetPreselectedUser(&userID);
 
         if (R_FAILED(rc)) {
-            printf("accountGetPreselectedUser() failed: 0x%x\n", rc);
+            printf("accountGetPreselectedUser() failed: 0x%x, using pselUi..\n", rc);
+            
+            /* Create player selection UI settings */
+            PselUiSettings settings;
+            rc = pselUiCreate(&settings, PselUiMode_UserSelector);
+
+            if (R_FAILED(rc)) {
+                printf("pselUiCreate() failed: 0x%x\n", rc);
+            } else {
+                /* Ask for a user account */
+                rc = pselUiShow(&settings, &userID);
+                if (R_FAILED(rc)) {
+                    printf("pselUiShow() failed: 0x%x\n", rc);
+                }
+            }
         }
 
         if (R_SUCCEEDED(rc)) {

--- a/account/source/main.c
+++ b/account/source/main.c
@@ -40,17 +40,13 @@ int main(int argc, char **argv)
             printf("accountGetPreselectedUser() failed: 0x%x, using pselUi..\n", rc);
             
             /* Create player selection UI settings */
-            PselUiSettings settings;
-            rc = pselUiCreate(&settings, PselUiMode_UserSelector);
+            PselUserSelectionSettings settings;
+            memset(&settings, 0, sizeof(settings));
+
+            rc = pselShowUserSelector(&userID, &settings);
 
             if (R_FAILED(rc)) {
-                printf("pselUiCreate() failed: 0x%x\n", rc);
-            } else {
-                /* Ask for a user account */
-                rc = pselUiShow(&settings, &userID);
-                if (R_FAILED(rc)) {
-                    printf("pselUiShow() failed: 0x%x\n", rc);
-                }
+                printf("pselShowUserSelector() failed: 0x%x\n", rc);
             }
         }
 

--- a/account/source/main.c
+++ b/account/source/main.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
             rc = pselShowUserSelector(&userID, &settings);
 
             if (R_FAILED(rc)) {
-                printf("pselShowUserSelector() failed: 0x%x\n", rc);
+                printf("using pselShowUserSelector() failed: 0x%x\n", rc);
             }
         }
 


### PR DESCRIPTION
**Summary**
This pull request adds support for multiple account handling in the account example.

**Validation**
I ran this using title takeover on:
- Snipperclips (Demo). The account example will ask on boot for the user to be selected.
- Animal Crossing: New Horizons. This game asks for the user on boot, and upon loading the example, it will grab the pre-selected user.