### PR TITLE
fs: add physfs example

### DIFF
--- a/fs/physfs/Makefile
+++ b/fs/physfs/Makefile
@@ -1,0 +1,222 @@
+#---------------------------------------------------------------------------------
+.SUFFIXES:
+#---------------------------------------------------------------------------------
+
+ifeq ($(strip $(DEVKITPRO)),)
+$(error "Please set DEVKITPRO in your environment. export DEVKITPRO=<path to>/devkitpro")
+endif
+
+TOPDIR ?= $(CURDIR)
+include $(DEVKITPRO)/libnx/switch_rules
+
+#---------------------------------------------------------------------------------
+# TARGET is the name of the output
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# DATA is a list of directories containing data files
+# INCLUDES is a list of directories containing header files
+# ROMFS is the directory containing data to be added to RomFS, relative to the Makefile (Optional)
+#
+# NO_ICON: if set to anything, do not use icon.
+# NO_NACP: if set to anything, no .nacp file is generated.
+# APP_TITLE is the name of the app stored in the .nacp file (Optional)
+# APP_AUTHOR is the author of the app stored in the .nacp file (Optional)
+# APP_VERSION is the version of the app stored in the .nacp file (Optional)
+# APP_TITLEID is the titleID of the app stored in the .nacp file (Optional)
+# ICON is the filename of the icon (.jpg), relative to the project folder.
+#   If not set, it attempts to use one of the following (in this order):
+#     - <Project name>.jpg
+#     - icon.jpg
+#     - <libnx folder>/default_icon.jpg
+#
+# CONFIG_JSON is the filename of the NPDM config file (.json), relative to the project folder.
+#   If not set, it attempts to use one of the following (in this order):
+#     - <Project name>.json
+#     - config.json
+#   If a JSON file is provided or autodetected, an ExeFS PFS0 (.nsp) is built instead
+#   of a homebrew executable (.nro). This is intended to be used for sysmodules.
+#   NACP building is skipped as well.
+#---------------------------------------------------------------------------------
+TARGET		:=	$(notdir $(CURDIR))
+BUILD		:=	build
+SOURCES		:=	source
+DATA		:=	data
+INCLUDES	:=	include
+#ROMFS	:=	romfs
+
+#---------------------------------------------------------------------------------
+# options for code generation
+#---------------------------------------------------------------------------------
+ARCH	:=	-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fPIE
+
+CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
+			$(ARCH) $(DEFINES)
+
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__
+
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
+
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+
+LIBS	:= -lnx -lphysfs
+
+#---------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level containing
+# include and lib
+#---------------------------------------------------------------------------------
+LIBDIRS	:= $(PORTLIBS) $(LIBNX)
+
+
+#---------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#---------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#---------------------------------------------------------------------------------
+
+export OUTPUT	:=	$(CURDIR)/$(TARGET)
+export TOPDIR	:=	$(CURDIR)
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir)) \
+			$(foreach dir,$(DATA),$(CURDIR)/$(dir))
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+#---------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#---------------------------------------------------------------------------------
+	export LD	:=	$(CC)
+#---------------------------------------------------------------------------------
+else
+#---------------------------------------------------------------------------------
+	export LD	:=	$(CXX)
+#---------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------
+
+export OFILES_BIN	:=	$(addsuffix .o,$(BINFILES))
+export OFILES_SRC	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+export OFILES 	:=	$(OFILES_BIN) $(OFILES_SRC)
+export HFILES_BIN	:=	$(addsuffix .h,$(subst .,_,$(BINFILES)))
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD)
+
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+ifeq ($(strip $(CONFIG_JSON)),)
+	jsons := $(wildcard *.json)
+	ifneq (,$(findstring $(TARGET).json,$(jsons)))
+		export APP_JSON := $(TOPDIR)/$(TARGET).json
+	else
+		ifneq (,$(findstring config.json,$(jsons)))
+			export APP_JSON := $(TOPDIR)/config.json
+		endif
+	endif
+else
+	export APP_JSON := $(TOPDIR)/$(CONFIG_JSON)
+endif
+
+ifeq ($(strip $(ICON)),)
+	icons := $(wildcard *.jpg)
+	ifneq (,$(findstring $(TARGET).jpg,$(icons)))
+		export APP_ICON := $(TOPDIR)/$(TARGET).jpg
+	else
+		ifneq (,$(findstring icon.jpg,$(icons)))
+			export APP_ICON := $(TOPDIR)/icon.jpg
+		endif
+	endif
+else
+	export APP_ICON := $(TOPDIR)/$(ICON)
+endif
+
+ifeq ($(strip $(NO_ICON)),)
+	export NROFLAGS += --icon=$(APP_ICON)
+endif
+
+ifeq ($(strip $(NO_NACP)),)
+	export NROFLAGS += --nacp=$(CURDIR)/$(TARGET).nacp
+endif
+
+ifneq ($(APP_TITLEID),)
+	export NACPFLAGS += --titleid=$(APP_TITLEID)
+endif
+
+ifneq ($(ROMFS),)
+	export NROFLAGS += --romfsdir=$(CURDIR)/$(ROMFS)
+endif
+
+.PHONY: $(BUILD) clean all
+
+#---------------------------------------------------------------------------------
+all: $(BUILD)
+
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+#---------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+ifeq ($(strip $(APP_JSON)),)
+	@rm -fr $(BUILD) $(TARGET).nro $(TARGET).nacp $(TARGET).elf
+else
+	@rm -fr $(BUILD) $(TARGET).nsp $(TARGET).nso $(TARGET).npdm $(TARGET).elf
+endif
+
+
+#---------------------------------------------------------------------------------
+else
+.PHONY:	all
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+#---------------------------------------------------------------------------------
+# main targets
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(APP_JSON)),)
+
+all	:	$(OUTPUT).nro
+
+ifeq ($(strip $(NO_NACP)),)
+$(OUTPUT).nro	:	$(OUTPUT).elf $(OUTPUT).nacp
+else
+$(OUTPUT).nro	:	$(OUTPUT).elf
+endif
+
+else
+
+all	:	$(OUTPUT).nsp
+
+$(OUTPUT).nsp	:	$(OUTPUT).nso $(OUTPUT).npdm
+
+$(OUTPUT).nso	:	$(OUTPUT).elf
+
+endif
+
+$(OUTPUT).elf	:	$(OFILES)
+
+$(OFILES_SRC)	: $(HFILES_BIN)
+
+#---------------------------------------------------------------------------------
+# you need a rule like this for each extension you use as binary data
+#---------------------------------------------------------------------------------
+%.bin.o	%_bin.h :	%.bin
+#---------------------------------------------------------------------------------
+	@echo $(notdir $<)
+	@$(bin2o)
+
+-include $(DEPENDS)
+
+#---------------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------------

--- a/fs/physfs/include/filesystem.h
+++ b/fs/physfs/include/filesystem.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <physfs.h>
+
+#include <string>
+#include <vector>
+
+namespace FileSystem
+{
+    static constexpr auto MAX_STAMP = 0x20000000000000LL;
+
+    enum FileMode
+    {
+        FileMode_Open,
+        FileMode_Read,
+        FileMode_Write,
+        FileMode_Closed
+    };
+
+    enum FileType
+    {
+        FileType_File,
+        FileType_Directory,
+        FileType_SymLink,
+        FileType_Other
+    };
+
+    struct File
+    {
+        PHYSFS_file* handle;
+        FileMode mode;
+
+        File()
+        {
+            this->handle = nullptr;
+            this->mode   = FileMode_Closed;
+        }
+
+        int64_t GetSize()
+        {
+            if (this->handle == nullptr)
+                return 0;
+
+            return (int64_t)PHYSFS_fileLength(this->handle);
+        }
+    };
+
+    struct Info
+    {
+        int64_t size;
+        int64_t mod_time;
+        FileType type;
+    };
+
+    void Initialize();
+
+    /*
+    ** mounts a specific directory for physfs to search in
+    ** this is typically a main directory
+    */
+    bool SetSource(const char* source);
+
+    /*
+    ** mounts a specific directory as a "save" directory
+    ** if appended, it will be added to the search path
+    */
+    bool SetIdentity(const char* name, bool append);
+
+    static std::string savePath;
+
+    /* gets the last physfs error */
+    const char* GetPhysfsError();
+
+    /* strips any duplicate slashes */
+    std::string Normalize(const std::string& input);
+
+    /* gets the user directory from physfs */
+    std::string GetUserDirectory();
+
+    /* gets the save directory */
+    std::string GetSaveDirectory();
+
+    /* sets up the writing directory for physfs */
+    bool SetupWriteDirectory();
+
+    /* gets a list of files in a directory */
+    void GetDirectoryItems(const char* directory, std::vector<std::string>& items);
+
+    /* gets the size, mod_time, and type of a file */
+    bool GetInfo(const char* filename, Info& info);
+
+    /* creates a new directory */
+    bool CreateDirectory(const char* name);
+
+    bool CloseFile(File& file);
+
+    /* creates a new file */
+    bool OpenFile(File& file, const char* name, FileMode mode);
+
+    /* writes to a file */
+    bool WriteFile(File& file, const void* data, int64_t size);
+
+    /* reads a file's content */
+    int64_t ReadFile(File& file, void* destination, int64_t size);
+}

--- a/fs/physfs/source/filesystem.cpp
+++ b/fs/physfs/source/filesystem.cpp
@@ -1,0 +1,285 @@
+#include "filesystem.h"
+
+#include <switch.h>
+
+#include <cstring>
+
+const char* FileSystem::GetPhysfsError()
+{
+    return PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
+}
+
+std::string FileSystem::Normalize(const std::string& input)
+{
+    std::string out;
+    bool seenSep = false, isSep = false;
+
+    for (size_t i = 0; i < input.size(); ++i)
+    {
+        isSep = (input[i] == '/');
+
+        if (!isSep || !seenSep)
+            out += input[i];
+
+        seenSep = isSep;
+    }
+
+    return out;
+}
+
+void FileSystem::Initialize()
+{
+    FileSystem::savePath = "";
+}
+
+bool FileSystem::SetSource(const char* source)
+{
+    if (!PHYSFS_isInit())
+        return false;
+
+    std::string searchPath = source;
+    if (!PHYSFS_mount(searchPath.c_str(), NULL, 1))
+        return false;
+
+    return true;
+}
+
+bool FileSystem::SetIdentity(const char* name, bool append)
+{
+    if (!PHYSFS_isInit())
+        return false;
+
+    std::string old = FileSystem::savePath;
+
+    FileSystem::savePath = FileSystem::Normalize(FileSystem::GetUserDirectory() + "/save/" + name);
+    printf("Save Path set to %s\n", savePath.c_str());
+
+    if (!old.empty())
+        PHYSFS_unmount(old.c_str());
+
+    int success = PHYSFS_mount(savePath.c_str(), NULL, append);
+    printf("Save Path mounted %d\n", success);
+
+    PHYSFS_setWriteDir(nullptr);
+
+    return true;
+}
+
+std::string FileSystem::GetSaveDirectory()
+{
+    return FileSystem::Normalize(FileSystem::GetUserDirectory() + "/save");
+}
+
+bool FileSystem::SetupWriteDirectory()
+{
+    if (!PHYSFS_isInit())
+        return false;
+
+    if (FileSystem::savePath.empty())
+        return false;
+
+    std::string tmpWritePath     = FileSystem::savePath;
+    std::string tmpDirectoryPath = FileSystem::savePath;
+
+    if (FileSystem::savePath.find(FileSystem::GetUserDirectory()) == 0)
+    {
+        tmpWritePath     = FileSystem::GetUserDirectory();
+        tmpDirectoryPath = savePath.substr(FileSystem::GetUserDirectory().length());
+
+        /* strip leading '/' characters from the path we want to create */
+        size_t startPosition = tmpDirectoryPath.find_first_not_of('/');
+
+        if (startPosition != std::string::npos)
+            tmpDirectoryPath = tmpDirectoryPath.substr(startPosition);
+    }
+
+    if (!PHYSFS_setWriteDir(tmpWritePath.c_str()))
+    {
+        printf("Failed to set write dir to %s\n", tmpWritePath.c_str());
+        return false;
+    }
+
+    if (!FileSystem::CreateDirectory(tmpDirectoryPath.c_str()))
+    {
+        printf("Failed to create dir %s\n", tmpDirectoryPath.c_str());
+        /* clear the write directory in case of error */
+        PHYSFS_setWriteDir(nullptr);
+        return false;
+    }
+
+    if (!PHYSFS_setWriteDir(savePath.c_str()))
+    {
+        printf("Failed to set write dir to %s\n", savePath.c_str());
+        return false;
+    }
+
+    if (!PHYSFS_mount(savePath.c_str(), nullptr, 0))
+    {
+        printf("Failed to mount write dir (%s)\n", FileSystem::GetPhysfsError());
+        /* clear the write directory in case of error */
+        PHYSFS_setWriteDir(nullptr);
+        return false;
+    }
+
+    return true;
+}
+
+std::string FileSystem::GetUserDirectory()
+{
+    return FileSystem::Normalize(PHYSFS_getUserDir());
+}
+
+bool FileSystem::GetInfo(const char* filename, FileSystem::Info& info)
+{
+    if (!PHYSFS_isInit())
+        return false;
+
+    PHYSFS_Stat stat = {};
+
+    if (!PHYSFS_stat(filename, &stat))
+        return false;
+
+    info.mod_time = std::min<int64_t>(stat.modtime, FileSystem::MAX_STAMP);
+    info.size     = std::min<int64_t>(stat.filesize, FileSystem::MAX_STAMP);
+
+    if (stat.filetype == PHYSFS_FILETYPE_REGULAR)
+        info.type = FileSystem::FileType_File;
+    else if (stat.filetype == PHYSFS_FILETYPE_DIRECTORY)
+        info.type = FileSystem::FileType_Directory;
+    else if (stat.filetype == PHYSFS_FILETYPE_SYMLINK)
+        info.type = FileSystem::FileType_SymLink;
+    else
+        info.type = FileSystem::FileType_Other;
+
+    return true;
+}
+
+void FileSystem::GetDirectoryItems(const char* path, std::vector<std::string>& items)
+{
+    if (!PHYSFS_isInit())
+        return;
+
+    char** results = PHYSFS_enumerateFiles(path);
+
+    if (results == nullptr)
+        return;
+
+    for (char** item = results; *item != 0; item++)
+        items.push_back(*item);
+
+    PHYSFS_freeList(results);
+}
+
+bool FileSystem::OpenFile(File& file, const char* name, FileMode mode)
+{
+    if (mode == FileMode_Closed)
+        return false;
+
+    if (!PHYSFS_isInit())
+        return false;
+
+    if (file.handle)
+        FileSystem::CloseFile(file);
+
+    if (mode == FileMode_Read && !PHYSFS_exists(name))
+    {
+        printf("Could not open file %s, does not exist.\n", name);
+        return false;
+    }
+
+    if ((mode == FileMode_Write) &&
+        (PHYSFS_getWriteDir() == nullptr && FileSystem::SetupWriteDirectory()))
+    {
+        printf("Could not set write directory.\n");
+        return false;
+    }
+
+    PHYSFS_getLastErrorCode();
+
+    switch (mode)
+    {
+        case FileMode_Read:
+            file.handle = PHYSFS_openRead(name);
+            break;
+        case FileMode_Write:
+            file.handle = PHYSFS_openWrite(name);
+            break;
+        default:
+            break;
+    }
+
+    if (!file.handle)
+    {
+        const char* error = FileSystem::GetPhysfsError();
+
+        if (error == nullptr)
+            error = "unknown error";
+
+        printf("Could not open file %s (%s)\n", name, error);
+
+        return false;
+    }
+
+    file.mode = mode;
+
+    return true;
+}
+
+bool FileSystem::CloseFile(File& file)
+{
+    if (file.handle == nullptr || !PHYSFS_close(file.handle))
+        return false;
+
+    file.handle = nullptr;
+
+    return true;
+}
+
+bool FileSystem::CreateDirectory(const char* name)
+{
+    if (!PHYSFS_isInit())
+        return false;
+
+    if (PHYSFS_getWriteDir() == nullptr && !FileSystem::SetupWriteDirectory())
+        return false;
+
+    if (!PHYSFS_mkdir(name))
+        return false;
+
+    return true;
+}
+
+int64_t FileSystem::ReadFile(File& file, void* destination, int64_t size)
+{
+    if (!file.handle || file.mode != FileMode_Read)
+    {
+        printf("File is not opened for reading.\n");
+        return 0;
+    }
+
+    if (size > file.GetSize())
+        size = file.GetSize();
+    else if (size < 0)
+    {
+        printf("Invalid read size %lld\n", size);
+        return 0;
+    }
+
+    return PHYSFS_readBytes(file.handle, destination, (PHYSFS_uint64)size);
+}
+
+bool FileSystem::WriteFile(File& file, const void* data, int64_t size)
+{
+    if (!file.handle || file.mode != FileMode_Write)
+    {
+        printf("File is not opened for writing.\n");
+        return false;
+    }
+
+    int64_t written = PHYSFS_writeBytes(file.handle, data, (PHYSFS_uint64)size);
+
+    if (written != size)
+        return false;
+
+    return true;
+}

--- a/fs/physfs/source/main.cpp
+++ b/fs/physfs/source/main.cpp
@@ -1,0 +1,122 @@
+#include <switch.h>
+
+#include "filesystem.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+static void listDirItems(const char* directory)
+{
+    std::vector<std::string> items;
+    FileSystem::GetDirectoryItems(directory, items);
+
+    printf("Directory listing of %s\n", directory);
+    for (const auto& filename : items)
+        printf("  -> %s\n", filename.c_str());
+}
+
+static const char* getInfoType(const FileSystem::Info& info)
+{
+    switch (info.type)
+    {
+        case FileSystem::FileType_File:
+            return "file";
+        case FileSystem::FileType_Directory:
+            return "directory";
+        case FileSystem::FileType_SymLink:
+            return "symlink";
+        case FileSystem::FileType_Other:
+            return "other";
+        default:
+            return "";
+    }
+}
+
+static void getInfo(const char* filepath)
+{
+    FileSystem::Info info;
+
+    bool success = FileSystem::GetInfo(filepath, info);
+
+    printf("File Info of %s\n", filepath);
+
+    if (success)
+    {
+        printf("  FileType: %s\n", getInfoType(info));
+        printf("  File Size: %ld\n", info.size);
+    }
+    else
+        printf("  Failed to get info for %s!\n", filepath);
+}
+
+int main(int argc, char** argv)
+{
+    consoleInit(NULL);
+
+    padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+
+    PadState pad;
+    padInitializeDefault(&pad);
+
+    printf("Press A to iterate the save directory\n");
+    printf("Press B to get info about MyFile.txt\n");
+    printf("Press X to get info about MyDir\n");
+    printf("Press Start to quit\n");
+
+    /* init can be passed NULL instead */
+    if (!PHYSFS_init(argv[0]))
+        printf("physfs failure: %s!\n", FileSystem::GetPhysfsError());
+
+    FileSystem::SetSource("game");
+    FileSystem::SetIdentity("game", true);
+
+    /* create a directory */
+    bool success = FileSystem::CreateDirectory("MyDir");
+    printf("Directory 'MyDir' Created: %d\n", success);
+
+    /* create a file and write to it */
+    FileSystem::File file{};
+    FileSystem::OpenFile(file, "MyFile.txt", FileSystem::FileMode_Write);
+
+    const char* message = "HELLO WORLD!";
+    size_t length       = strlen(message);
+
+    FileSystem::WriteFile(file, message, length);
+    success = FileSystem::CloseFile(file);
+    printf("File Closed: %d\n", success);
+
+    /* open our file for reading */
+    FileSystem::OpenFile(file, "MyFile.txt", FileSystem::FileMode_Read);
+    char buffer[file.GetSize() + 1] = {'\0'};
+
+    /* read the file contents and print them */
+    int64_t size = FileSystem::ReadFile(file, buffer, file.GetSize());
+
+    if (size != 0)
+        printf("File Contents: %s\n", buffer);
+
+    while (appletMainLoop())
+    {
+        padUpdate(&pad);
+        uint64_t kDown = padGetButtonsDown(&pad);
+
+        if (kDown & HidNpadButton_Plus)
+            break;
+        else if (kDown & HidNpadButton_A)
+            listDirItems("");
+        else if (kDown & HidNpadButton_B)
+            getInfo("MyFile.txt");
+        else if (kDown & HidNpadButton_X)
+            getInfo("MyDir");
+
+        consoleUpdate(NULL);
+    }
+
+    consoleExit(NULL);
+
+    return 0;
+}


### PR DESCRIPTION
This adds an example for physfs usage under the `fs` directory. See [this pr for 3ds-examples](https://github.com/devkitPro/3ds-examples/pull/50) for more details.