### PR TITLE
Delete various copy constructors and assignment operators

### DIFF
--- a/graphics/deko3d/deko_examples/source/SampleFramework/CCmdMemRing.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CCmdMemRing.h
@@ -18,6 +18,8 @@ public:
 
     CCmdMemRing(const CCmdMemRing&) = delete;
 
+    CCmdMemRing& operator=(const CCmdMemRing&) = delete;
+
     ~CCmdMemRing()
     {
         m_mem.destroy();

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CCmdMemRing.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CCmdMemRing.h
@@ -15,6 +15,9 @@ class CCmdMemRing
     dk::Fence m_fences[NumSlices];
 public:
     CCmdMemRing() : m_mem{}, m_curSlice{}, m_fences{} { }
+
+    CCmdMemRing(const CCmdMemRing&) = delete;
+
     ~CCmdMemRing()
     {
         m_mem.destroy();

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CDescriptorSet.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CDescriptorSet.h
@@ -20,7 +20,9 @@ public:
 	CDescriptorSet() : m_mem{} { }
 
     CDescriptorSet(const CDescriptorSet&) = delete;
-	
+
+    CDescriptorSet& operator=(const CDescriptorSet&) = delete;
+
     ~CDescriptorSet()
 	{
 		m_mem.destroy();

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CDescriptorSet.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CDescriptorSet.h
@@ -18,7 +18,10 @@ class CDescriptorSet
 	CMemPool::Handle m_mem;
 public:
 	CDescriptorSet() : m_mem{} { }
-	~CDescriptorSet()
+
+    CDescriptorSet(const CDescriptorSet&) = delete;
+	
+    ~CDescriptorSet()
 	{
 		m_mem.destroy();
 	}

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CExternalImage.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CExternalImage.h
@@ -15,7 +15,9 @@ public:
     CExternalImage() : m_image{}, m_descriptor{}, m_mem{} { }
 
     CExternalImage(const CExternalImage&) = delete;
-    
+
+    CExternalImage& operator=(const CExternalImage&) = delete;
+
     ~CExternalImage()
     {
         m_mem.destroy();

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CExternalImage.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CExternalImage.h
@@ -13,6 +13,9 @@ class CExternalImage
     CMemPool::Handle m_mem;
 public:
     CExternalImage() : m_image{}, m_descriptor{}, m_mem{} { }
+
+    CExternalImage(const CExternalImage&) = delete;
+    
     ~CExternalImage()
     {
         m_mem.destroy();

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
@@ -74,8 +74,6 @@ public:
         constexpr bool operator==(Handle const& rhs) const { return m_slice == rhs.m_slice; }
         constexpr bool operator!=(Handle const& rhs) const { return m_slice != rhs.m_slice; }
 
-        Handle(const Handle&) = delete;
-
         void destroy()
         {
             if (m_slice)

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
@@ -20,6 +20,8 @@ class CMemPool
         void* m_cpuAddr;
         DkGpuAddr m_gpuAddr;
 
+        Block(const Block&) = delete;
+
         constexpr void* cpuOffset(uint32_t offset) const
         {
             return m_cpuAddr ? ((u8*)m_cpuAddr + offset) : nullptr;

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
@@ -42,6 +42,8 @@ class CMemPool
         uint32_t m_start;
         uint32_t m_end;
 
+        Slice(const Slice&) = delete;
+        
         constexpr uint32_t getSize() const { return m_end - m_start; }
         constexpr bool canCoalesce(Slice const& rhs) const { return m_pool == rhs.m_pool && m_block == rhs.m_block && m_end == rhs.m_start; }
 
@@ -71,6 +73,8 @@ public:
         constexpr bool operator!() const { return !m_slice; }
         constexpr bool operator==(Handle const& rhs) const { return m_slice == rhs.m_slice; }
         constexpr bool operator!=(Handle const& rhs) const { return m_slice != rhs.m_slice; }
+
+        Handle(const Handle&) = delete;
 
         void destroy()
         {
@@ -109,9 +113,12 @@ public:
 
     CMemPool(dk::Device dev, uint32_t flags = DkMemBlockFlags_CpuUncached | DkMemBlockFlags_GpuCached, uint32_t blockSize = DefaultBlockSize) :
         m_dev{dev}, m_flags{flags}, m_blockSize{blockSize}, m_blocks{}, m_memMap{}, m_sliceHeap{}, m_freeList{} { }
+
     ~CMemPool();
 
     Handle allocate(uint32_t size, uint32_t alignment = DK_CMDMEM_ALIGNMENT);
+
+    CMemPool(const CMemPool&) = delete;
 };
 
 constexpr bool operator<(uint32_t lhs, CMemPool::Slice const& rhs)

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CMemPool.h
@@ -22,6 +22,8 @@ class CMemPool
 
         Block(const Block&) = delete;
 
+        Block& operator=(const Block&) = delete;
+
         constexpr void* cpuOffset(uint32_t offset) const
         {
             return m_cpuAddr ? ((u8*)m_cpuAddr + offset) : nullptr;
@@ -45,7 +47,9 @@ class CMemPool
         uint32_t m_end;
 
         Slice(const Slice&) = delete;
-        
+
+        Slice& operator=(const Slice&) = delete;
+
         constexpr uint32_t getSize() const { return m_end - m_start; }
         constexpr bool canCoalesce(Slice const& rhs) const { return m_pool == rhs.m_pool && m_block == rhs.m_block && m_end == rhs.m_start; }
 
@@ -119,6 +123,8 @@ public:
     Handle allocate(uint32_t size, uint32_t alignment = DK_CMDMEM_ALIGNMENT);
 
     CMemPool(const CMemPool&) = delete;
+
+    CMemPool& operator=(const CMemPool&) = delete;
 };
 
 constexpr bool operator<(uint32_t lhs, CMemPool::Slice const& rhs)

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CShader.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CShader.h
@@ -14,7 +14,9 @@ public:
     CShader() : m_shader{}, m_codemem{} { }
 
     CShader(const CShader&) = delete;
-    
+
+    CShader& operator=(const CShader&) = delete;
+
     ~CShader()
     {
         m_codemem.destroy();

--- a/graphics/deko3d/deko_examples/source/SampleFramework/CShader.h
+++ b/graphics/deko3d/deko_examples/source/SampleFramework/CShader.h
@@ -12,6 +12,9 @@ class CShader
     CMemPool::Handle m_codemem;
 public:
     CShader() : m_shader{}, m_codemem{} { }
+
+    CShader(const CShader&) = delete;
+    
     ~CShader()
     {
         m_codemem.destroy();


### PR DESCRIPTION
DIscussed with @fincs, some of the classes that are used inside of the deko3d sample application framework should have their copy constructors deleted. This prevents lifetime issues with the objects which can lead to bad things™ (I would know).