### PR TITLE
power: Update charger enum

### DIFF
--- a/power/source/main.c
+++ b/power/source/main.c
@@ -4,7 +4,7 @@
 
 #include <switch.h>
 
-const char* const chargers[3] = {"None", "Official", "Generic"};
+const char* const chargers[4] = {"None", "Full Power", "Low Power", "Unsupported"};
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
I updated the definitions 3 years ago (https://github.com/switchbrew/libnx/commit/7e29719263e5a5ab3d8d4111e84da529c88f806d) and apparently forgot to push the PR to fix the example.