### PR TITLE
Fixed default .json

### DIFF
--- a/templates/sysmodule/sysmodule.json
+++ b/templates/sysmodule/sysmodule.json
@@ -166,8 +166,8 @@
 			"type":	"debug_flags",
 			"value":	{
 				"allow_debug":	false,
-				"force_debug":	true,
-				"force_debug_prod":	false
+				"force_debug":	false,
+				"force_debug_prod":	true
 			}
 		}]
 }


### PR DESCRIPTION
Previously, when building sysmodule, .The default json file in the project could not allow it to be built. I propose this solution